### PR TITLE
fix api missmatch

### DIFF
--- a/lightweightlibrary/lib/app/series/series-instance.js
+++ b/lightweightlibrary/lib/app/series/series-instance.js
@@ -83,6 +83,8 @@ export default class SeriesInstanceService {
             new RemoveSeries(this.chart, this.seriesCache, this.markersCache, this.lineCache, this.functionManager),
             new PriceToCoordinate(),
             new CoordinateToPrice(),
+            new BarsInLogicalRange(),
+            new PriceFormatterFormat(),
             new Options(this.pluginManager),
             new DataByIndex(),
             new SeriesType(),
@@ -195,6 +197,22 @@ class CoordinateToPrice extends SeriesInstanceMethod {
     constructor() {
         super("coordinateToPrice", function (series, params, resolve) {
             resolve(series.coordinateToPrice(params.coordinate));
+        });
+    }
+}
+
+class BarsInLogicalRange extends SeriesInstanceMethod {
+    constructor() {
+        super("barsInLogicalRange", function (series, params, resolve) {
+            resolve(series.barsInLogicalRange(params.range));
+        });
+    }
+}
+
+class PriceFormatterFormat extends SeriesInstanceMethod {
+    constructor() {
+        super("priceFormatterFormat", function (series, params, resolve) {
+            resolve(series.priceFormatter().format(params.price));
         });
     }
 }

--- a/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/delegates/PriceFormatterApiDelegate.kt
+++ b/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/delegates/PriceFormatterApiDelegate.kt
@@ -1,0 +1,26 @@
+package com.tradingview.lightweightcharts.api.delegates
+
+import com.tradingview.lightweightcharts.api.interfaces.PriceFormatterApi
+import com.tradingview.lightweightcharts.api.interfaces.PriceFormatterApi.Func.PRICE_FORMATTER_FORMAT
+import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Params.PRICE
+import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Params.SERIES_UUID
+import com.tradingview.lightweightcharts.api.serializer.PrimitiveSerializer
+import com.tradingview.lightweightcharts.runtime.controller.WebMessageController
+
+class PriceFormatterApiDelegate(
+    private val seriesId: String,
+    private val controller: WebMessageController,
+) : PriceFormatterApi {
+
+    override fun format(price: Float, onFormatted: (String) -> Unit) {
+        controller.callFunction(
+            PRICE_FORMATTER_FORMAT,
+            mapOf(
+                SERIES_UUID to seriesId,
+                PRICE to price
+            ),
+            callback = onFormatted,
+            deserializer = PrimitiveSerializer.StringDeserializer
+        )
+    }
+}

--- a/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/delegates/SeriesApiDelegate.kt
+++ b/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/delegates/SeriesApiDelegate.kt
@@ -1,9 +1,11 @@
 package com.tradingview.lightweightcharts.api.delegates
 
+import com.tradingview.lightweightcharts.api.interfaces.PriceFormatterApi
 import com.tradingview.lightweightcharts.api.interfaces.PriceScaleApi
 import com.tradingview.lightweightcharts.api.interfaces.SeriesApi
 import com.tradingview.lightweightcharts.api.interfaces.SeriesMarkersApi
 import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Func.APPLY_OPTIONS
+import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Func.BARS_IN_LOGICAL_RANGE
 import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Func.COORDINATE_TO_PRICE
 import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Func.DATA as SERIES_DATA
 import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Func.CREATE_SERIES_MARKERS_COMPAT
@@ -37,6 +39,7 @@ import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Params.OPTIONS
 import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Params.ORDER
 import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Params.PANE_INDEX
 import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Params.PRICE
+import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Params.RANGE
 import com.tradingview.lightweightcharts.api.interfaces.SeriesApi.Params.SERIES_UUID
 import com.tradingview.lightweightcharts.api.options.enums.MismatchDirection
 import com.tradingview.lightweightcharts.api.options.models.AreaSeriesOptions
@@ -49,6 +52,7 @@ import com.tradingview.lightweightcharts.api.options.models.PriceLineOptions
 import com.tradingview.lightweightcharts.api.options.models.SeriesMarkersOptions
 import com.tradingview.lightweightcharts.api.options.models.SeriesOptionsCommon
 import com.tradingview.lightweightcharts.api.serializer.AreaSeriesOptionsDeserializer
+import com.tradingview.lightweightcharts.api.serializer.BarsInfoDeserializer
 import com.tradingview.lightweightcharts.api.serializer.BarSeriesOptionsDeserializer
 import com.tradingview.lightweightcharts.api.serializer.BaselineSeriesOptionsDeserializer
 import com.tradingview.lightweightcharts.api.serializer.ClassSimpleDeserializer
@@ -65,7 +69,9 @@ import com.tradingview.lightweightcharts.api.series.common.PriceLine
 import com.tradingview.lightweightcharts.api.series.common.PriceLineDelegate
 import com.tradingview.lightweightcharts.api.series.common.SeriesData
 import com.tradingview.lightweightcharts.api.series.enums.SeriesType
+import com.tradingview.lightweightcharts.api.series.models.BarsInfo
 import com.tradingview.lightweightcharts.api.series.models.LastValueData
+import com.tradingview.lightweightcharts.api.series.models.LogicalRange
 import com.tradingview.lightweightcharts.api.series.models.SeriesMarker
 import com.tradingview.lightweightcharts.runtime.controller.WebMessageController
 import com.tradingview.lightweightcharts.runtime.version.ChartRuntimeObject
@@ -135,6 +141,22 @@ class SeriesApiDelegate<T : SeriesOptionsCommon>(
             callback = onPriceReceived,
             PrimitiveSerializer.FloatDeserializer
         )
+    }
+
+    override fun barsInLogicalRange(range: LogicalRange, onBarsInfoReceived: (BarsInfo?) -> Unit) {
+        controller.callFunction(
+            BARS_IN_LOGICAL_RANGE,
+            mapOf(
+                SERIES_UUID to uuid,
+                RANGE to range
+            ),
+            callback = onBarsInfoReceived,
+            deserializer = BarsInfoDeserializer()
+        )
+    }
+
+    override fun priceFormatter(): PriceFormatterApi {
+        return PriceFormatterApiDelegate(uuid, controller)
     }
 
     override fun applyOptions(options: SeriesOptionsCommon) {

--- a/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/interfaces/PriceFormatterApi.kt
+++ b/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/interfaces/PriceFormatterApi.kt
@@ -1,0 +1,18 @@
+package com.tradingview.lightweightcharts.api.interfaces
+
+/**
+ * Interface to be implemented by the object in order to be used as a price formatter
+ */
+interface PriceFormatterApi {
+
+    object Func {
+        const val PRICE_FORMATTER_FORMAT = "priceFormatterFormat"
+    }
+
+    /**
+     * Formats the price using the series price formatter
+     * @param price the price to be formatted
+     * @param onFormatted the formatted price
+     */
+    fun format(price: Float, onFormatted: (String) -> Unit)
+}

--- a/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/interfaces/SeriesApi.kt
+++ b/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/interfaces/SeriesApi.kt
@@ -7,7 +7,9 @@ import com.tradingview.lightweightcharts.api.options.models.SeriesOptionsCommon
 import com.tradingview.lightweightcharts.api.series.common.PriceLine
 import com.tradingview.lightweightcharts.api.series.common.SeriesData
 import com.tradingview.lightweightcharts.api.series.enums.SeriesType
+import com.tradingview.lightweightcharts.api.series.models.BarsInfo
 import com.tradingview.lightweightcharts.api.series.models.LastValueData
+import com.tradingview.lightweightcharts.api.series.models.LogicalRange
 import com.tradingview.lightweightcharts.api.series.models.SeriesMarker
 
 interface SeriesApi {
@@ -22,6 +24,7 @@ interface SeriesApi {
         const val SET_SERIES = "setSeries"
         const val PRICE_TO_COORDINATE = "priceToCoordinate"
         const val COORDINATE_TO_PRICE = "coordinateToPrice"
+        const val BARS_IN_LOGICAL_RANGE = "barsInLogicalRange"
         const val APPLY_OPTIONS = "applyOptionsSeries"
         const val PRICE_SCALE_SERIES = "priceScaleSeries"
         const val DATA_BY_INDEX_SERIES = "dataByIndexSeries"
@@ -57,6 +60,7 @@ interface SeriesApi {
         const val ORDER = "order"
         const val PANE_INDEX = "paneIndex"
         const val GLOBAL_LAST = "globalLast"
+        const val RANGE = "range"
     }
 
     val uuid: String
@@ -74,6 +78,19 @@ interface SeriesApi {
      * @param onPriceReceived price value of the coordinate on the chart
      */
     fun coordinateToPrice(coordinate: Float, onPriceReceived: (Float?) -> Unit)
+
+    /**
+     * Returns bars information for the series in the provided logical range
+     * @param range the logical range to retrieve info for
+     * @param onBarsInfoReceived bars information for the series in the provided range,
+     * or null if no series data has been found in the requested range
+     */
+    fun barsInLogicalRange(range: LogicalRange, onBarsInfoReceived: (BarsInfo?) -> Unit)
+
+    /**
+     * Returns the interface of the price formatter applied to the series
+     */
+    fun priceFormatter(): PriceFormatterApi
 
     /**
      * Applies new options to the existing series

--- a/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/common/LineStyleOptions.kt
+++ b/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/common/LineStyleOptions.kt
@@ -18,5 +18,6 @@ interface LineStyleOptions {
     val crosshairMarkerRadius: Float?
     val crosshairMarkerBorderColor: IntColor?
     val crosshairMarkerBackgroundColor: IntColor?
+    val crosshairMarkerBorderWidth: Float?
     val lastPriceAnimation: LastPriceAnimationMode?
 }

--- a/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/enums/ColorSpace.kt
+++ b/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/enums/ColorSpace.kt
@@ -1,0 +1,11 @@
+package com.tradingview.lightweightcharts.api.options.enums
+
+import com.google.gson.annotations.SerializedName
+
+enum class ColorSpace {
+    @SerializedName("srgb")
+    SRGB,
+
+    @SerializedName("display-p3")
+    DISPLAY_P3,
+}

--- a/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/AreaSeriesOptions.kt
+++ b/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/AreaSeriesOptions.kt
@@ -93,6 +93,11 @@ data class AreaSeriesOptions(
      */
     override var visible: Boolean? = null,
 
+    /**
+     * Additional tolerance in pixels used when hit testing the series
+     */
+    override var hitTestTolerance: Float? = null,
+
     // ----------  AreaStyleOptions    ---------------------
     /**
      * Color of the top part of the area.

--- a/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/BarSeriesOptions.kt
+++ b/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/BarSeriesOptions.kt
@@ -38,6 +38,7 @@ data class BarSeriesOptions(
     override var priceScaleId: PriceScaleId? = null,
     override var autoscaleInfoProvider: Plugin? = null,
     override var visible: Boolean? = null,
+    override var hitTestTolerance: Float? = null,
     override var conflationThresholdFactor: Float? = null,
 ) : SeriesOptionsCommon, BarStyleOptions
 

--- a/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/BaselineSeriesOptions.kt
+++ b/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/BaselineSeriesOptions.kt
@@ -100,7 +100,9 @@ data class BaselineSeriesOptions(
 
     // ------------  BaselineStyleOptions  ----------
     /**
-     override * rase value of the series.=null,
+     * Base value of the series.
+     *
+     * Default value: `{ type: 'price', price: 0 }`
      */
     override var baseValue: BaseValueType? = null,
 

--- a/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/BaselineSeriesOptions.kt
+++ b/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/BaselineSeriesOptions.kt
@@ -93,6 +93,11 @@ data class BaselineSeriesOptions(
      */
     override var visible: Boolean? = null,
 
+    /**
+     * Additional tolerance in pixels used when hit testing the series
+     */
+    override var hitTestTolerance: Float? = null,
+
     // ------------  BaselineStyleOptions  ----------
     /**
      override * rase value of the series.=null,

--- a/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/CandlestickSeriesOptions.kt
+++ b/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/CandlestickSeriesOptions.kt
@@ -50,6 +50,7 @@ data class CandlestickSeriesOptions(
     override var priceScaleId: PriceScaleId? = null,
     override var autoscaleInfoProvider: Plugin? = null,
     override var visible: Boolean? = null,
+    override var hitTestTolerance: Float? = null,
     override var conflationThresholdFactor: Float? = null,
 ) : SeriesOptionsCommon, CandlestickStyleOptions
 

--- a/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/ChartOptions.kt
+++ b/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/ChartOptions.kt
@@ -8,8 +8,13 @@ import com.tradingview.lightweightcharts.api.options.enums.PriceScaleSide
  */
 data class ChartOptions(
     /**
+     * ## Deprecated
+     * Watermark is no longer a chart option in Lightweight Charts v5.
+     * Use the watermark plugin API [com.tradingview.lightweightcharts.api.interfaces.ChartApi.createTextWatermark] instead.
+     *
      * Structure with watermark options
      */
+    @Deprecated("Watermark is no longer a chart option in v5. Use ChartApi.createTextWatermark/createImageWatermark instead.")
     var watermark: WatermarkOptions? = null,
 
     /**

--- a/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/HistogramSeriesOptions.kt
+++ b/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/HistogramSeriesOptions.kt
@@ -34,6 +34,7 @@ data class HistogramSeriesOptions(
     override var priceScaleId: PriceScaleId? = null,
     override var autoscaleInfoProvider: Plugin? = null,
     override var visible: Boolean? = null,
+    override var hitTestTolerance: Float? = null,
     override var conflationThresholdFactor: Float? = null,
 ) : SeriesOptionsCommon, HistogramStyleOptions
 

--- a/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/LayoutOptions.kt
+++ b/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/LayoutOptions.kt
@@ -2,6 +2,7 @@ package com.tradingview.lightweightcharts.api.options.models
 
 import com.tradingview.lightweightcharts.api.chart.models.color.IntColor
 import com.tradingview.lightweightcharts.api.chart.models.color.surface.SurfaceColor
+import com.tradingview.lightweightcharts.api.options.enums.ColorSpace
 
 data class LayoutOptions(
 
@@ -34,6 +35,12 @@ data class LayoutOptions(
      * Options for chart layout panes.
      */
     var panes: LayoutPanesOptions? = null,
+
+    /**
+     * The color space to use for the chart rendering. The display-p3 color space
+     * provides a wider gamut of colors but requires a compatible display.
+     */
+    var colorSpace: ColorSpace? = null,
 )
 
 inline fun layoutOptions(init: LayoutOptions.() -> Unit): LayoutOptions {

--- a/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/LineSeriesOptions.kt
+++ b/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/LineSeriesOptions.kt
@@ -46,9 +46,12 @@ data class LineSeriesOptions(
 
     override var crosshairMarkerBackgroundColor: IntColor? = null,
 
+    override var crosshairMarkerBorderWidth: Float? = null,
+
     override var priceScaleId: PriceScaleId? = null,
     override var autoscaleInfoProvider: Plugin? = null,
     override var visible: Boolean? = null,
+    override var hitTestTolerance: Float? = null,
     override var conflationThresholdFactor: Float? = null,
     override var lastPriceAnimation: LastPriceAnimationMode? = null,
 ) : SeriesOptionsCommon, LineStyleOptions

--- a/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/LocalizationOptions.kt
+++ b/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/LocalizationOptions.kt
@@ -15,6 +15,11 @@ data class LocalizationOptions(
     var priceFormatter: Plugin? = null,
 
     /**
+     * User-defined function for percentage formatting.
+     */
+    var percentageFormatter: Plugin? = null,
+
+    /**
      * User-defined function for time formatting.
      */
     var timeFormatter: Plugin? = null,

--- a/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/PriceLineOptions.kt
+++ b/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/PriceLineOptions.kt
@@ -41,6 +41,17 @@ data class PriceLineOptions(
     var axisLabelVisible: Boolean? = null,
 
     /**
+     * Background color for the axis label.
+     * Will default to the price line color if unspecified.
+     */
+    var axisLabelColor: IntColor? = null,
+
+    /**
+     * Text color for the axis label.
+     */
+    var axisLabelTextColor: IntColor? = null,
+
+    /**
      * Price line's on the chart pane.
      */
     var title: String? = null,

--- a/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/PriceScaleOptions.kt
+++ b/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/PriceScaleOptions.kt
@@ -30,7 +30,7 @@ data class PriceScaleOptions(
     /**
      * Defines position of the price scale on the chart
      */
-    @Deprecated("")
+    @Deprecated("Removed in Lightweight Charts v5 and ignored by the library. Use leftPriceScale/rightPriceScale visibility and priceScaleId instead.")
     var position: PriceAxisPosition? = null,
 
     /**

--- a/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/SeriesOptionsCommon.kt
+++ b/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/SeriesOptionsCommon.kt
@@ -91,6 +91,11 @@ interface SeriesOptionsCommon {
     val visible: Boolean?
 
     /**
+     * Additional tolerance in pixels used when hit testing the series
+     */
+    val hitTestTolerance: Float?
+
+    /**
      * Series-level conflation smoothing factor. Overrides the global time scale option when set.
      */
     val conflationThresholdFactor: Float?

--- a/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/TimeScaleOptions.kt
+++ b/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/options/models/TimeScaleOptions.kt
@@ -73,6 +73,12 @@ data class TimeScaleOptions(
     var shiftVisibleRangeOnNewBar: Boolean? = null,
 
     /**
+     * Allow the visible range to be shifted to the right when a new bar is added
+     * which is replacing an existing whitespace time point on the chart
+     */
+    var allowShiftVisibleRangeOnWhitespaceReplacement: Boolean? = null,
+
+    /**
      * Allows to override the tick marks formatter
      */
     var tickMarkFormatter: Plugin? = null,
@@ -101,6 +107,22 @@ data class TimeScaleOptions(
      * Minimum time scale height.
      */
     var minimumHeight: Int? = null,
+
+    /**
+     * Changes horizontal alignment of the time scale tick marks to a uniform distribution.
+     */
+    var uniformDistribution: Boolean? = null,
+
+    /**
+     * Allow major time scale labels to be rendered in a bolder font weight.
+     */
+    var allowBoldLabels: Boolean? = null,
+
+    /**
+     * Ignore time scale points containing only whitespace
+     * when drawing grid lines, tick marks, and snapping the crosshair.
+     */
+    var ignoreWhitespaceIndices: Boolean? = null,
 
     var enableConflation: Boolean? = null,
     var conflationThresholdFactor: Float? = null,

--- a/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/serializer/BarsInfoDeserializer.kt
+++ b/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/serializer/BarsInfoDeserializer.kt
@@ -1,0 +1,46 @@
+package com.tradingview.lightweightcharts.api.serializer
+
+import com.google.gson.JsonElement
+import com.tradingview.lightweightcharts.api.series.models.BarsInfo
+import com.tradingview.lightweightcharts.api.series.models.Time
+import com.tradingview.lightweightcharts.help.isNumber
+import com.tradingview.lightweightcharts.help.isString
+
+class BarsInfoDeserializer : Deserializer<BarsInfo>() {
+
+    override fun deserialize(json: JsonElement): BarsInfo? {
+        if (!json.isJsonObject) {
+            return null
+        }
+        val jsonObject = json.asJsonObject
+        val barsBefore = jsonObject.get("barsBefore") ?: return null
+        val barsAfter = jsonObject.get("barsAfter") ?: return null
+
+        return BarsInfo(
+            from = jsonObject.get("from")?.let(::parseTime),
+            to = jsonObject.get("to")?.let(::parseTime),
+            barsBefore = barsBefore.asFloat,
+            barsAfter = barsAfter.asFloat,
+        )
+    }
+
+    private fun parseTime(value: JsonElement): Time? {
+        return when {
+            value.isJsonNull -> null
+            value.isNumber() -> Time.Utc(value.asLong)
+            value.isString() -> value.asString.toLongOrNull()?.let(Time::Utc)
+                ?: Time.StringTime(value.asString)
+            value.isJsonObject -> {
+                val date = value.asJsonObject
+                runCatching {
+                    Time.BusinessDay(
+                        date.get("year").asInt,
+                        date.get("month").asInt,
+                        date.get("day").asInt
+                    )
+                }.getOrNull()
+            }
+            else -> null
+        }
+    }
+}

--- a/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/series/models/BarsInfo.kt
+++ b/lightweightlibrary/src/main/java/com/tradingview/lightweightcharts/api/series/models/BarsInfo.kt
@@ -1,0 +1,30 @@
+package com.tradingview.lightweightcharts.api.series.models
+
+/**
+ * Represents a range of bars and the number of bars outside the range.
+ */
+data class BarsInfo(
+    /**
+     * The time of the first bar in the range, if any bars are in the range.
+     */
+    val from: Time? = null,
+
+    /**
+     * The time of the last bar in the range, if any bars are in the range.
+     */
+    val to: Time? = null,
+
+    /**
+     * The number of bars before the start of the range.
+     * Positive if there are some bars before the range,
+     * negative if the first bar of the series is inside the range.
+     */
+    val barsBefore: Float,
+
+    /**
+     * The number of bars after the end of the range.
+     * Positive if there are some bars after the range,
+     * negative if the last bar of the series is inside the range.
+     */
+    val barsAfter: Float,
+)


### PR DESCRIPTION

### Options & API parity with lightweight-charts v5.2.0

Closes the wrapper↔JS-library gaps found in a full parity audit (counterpart to the iOS parity PR).

- **Series options:** `crosshairMarkerBorderWidth` on `LineSeriesOptions` (Area/Baseline already had it); `hitTestTolerance` added to `SeriesOptionsCommon` and all six series options
- **Price lines:** `axisLabelColor`, `axisLabelTextColor`
- **Localization:** `percentageFormatter`
- **Time scale:** `uniformDistribution`, `allowBoldLabels`, `ignoreWhitespaceIndices`, `allowShiftVisibleRangeOnWhitespaceReplacement`
- **Layout:** `colorSpace` (new `ColorSpace` enum)
- **New API:** `SeriesApi.barsInLogicalRange()` (new `BarsInfo` model) and `SeriesApi.priceFormatter()` (new `PriceFormatterApi`), with matching bridge functions in `lib/app/series/series-instance.js`
- **Deprecations:** `ChartOptions.watermark` now carries `@Deprecated` pointing to `createTextWatermark`/`createImageWatermark`; real message on `PriceScaleOptions.position`

Verified: `:lightweightlibrary:compileDebugKotlin` passes; bridge bundle rebuilt via `npm run compile`; all new fields validated against the v5.2.0 `typings.d.ts`.